### PR TITLE
Xdebug noupsh

### DIFF
--- a/.docker/install-multisite
+++ b/.docker/install-multisite
@@ -28,7 +28,7 @@ wp core download --allow-root --path=/var/www/html/wordpress
 if ! $(wp core is-installed --allow-root --path=/var/www/html/wordpress); then
     wp core multisite-install \
         --allow-root \
-        --path=/usr/src/wordpress \
+        --path=/var/www/wordpress \
         --subdomains \
         --url=${WP_DOMAIN} \
         --title="Docker WordPress" \

--- a/.docker/install-multisite
+++ b/.docker/install-multisite
@@ -23,6 +23,8 @@ done
 
 echo "Database is available. Continuing"
 
+wp core download --path=/usr/src/wordpress
+
 if ! $(wp core is-installed --allow-root --path=/usr/src/wordpress); then
     wp core multisite-install \
         --allow-root \

--- a/.docker/install-multisite
+++ b/.docker/install-multisite
@@ -36,4 +36,41 @@ if ! $(wp core is-installed --allow-root --path=/usr/src/wordpress); then
         --skip-email
 fi
 
+# Ensure the plugin and theme directories exist
+mkdir -p wp-content/themes
+mkdir -p wp-content/plugins
+
+# Checkout/update VIP plugins
+echo
+echo "Checking out VIP Plugins..."
+if [ -d "wp-content/themes/vip/plugins" ]; then
+  svn up wp-content/themes/vip/plugins
+else
+  mkdir -p wp-content/themes/vip
+  svn co https://vip-svn.wordpress.com/plugins/ wp-content/themes/vip/plugins
+fi
+
+# Checkout/update default theme
+echo
+echo "Checking out default theme..."
+if [ -d "wp-content/themes/pub/twentysixteen" ]; then
+  svn up wp-content/themes/pub/twentysixteen
+else
+  mkdir -p wp-content/themes/pub
+  svn co https://wpcom-themes.svn.automattic.com/twentysixteen wp-content/themes/pub/twentysixteen
+fi
+
+# Clone Jetpack
+echo
+echo "Cloning Jetpack..."
+if [ -d "wp-content/plugins/jetpack" ]; then
+  cd wp-content/plugins/jetpack
+  git reset --hard
+  git pull
+  cd -
+else
+  git clone -b master-stable https://github.com/Automattic/jetpack.git wp-content/plugins/jetpack
+fi
+
+
 php-fpm -F

--- a/.docker/install-multisite
+++ b/.docker/install-multisite
@@ -23,9 +23,9 @@ done
 
 echo "Database is available. Continuing"
 
-wp core download --path=/usr/src/wordpress
+wp core download --allow-root --path=/var/www/html/wordpress
 
-if ! $(wp core is-installed --allow-root --path=/usr/src/wordpress); then
+if ! $(wp core is-installed --allow-root --path=/var/www/html/wordpress); then
     wp core multisite-install \
         --allow-root \
         --path=/usr/src/wordpress \

--- a/.docker/install-multisite
+++ b/.docker/install-multisite
@@ -37,39 +37,39 @@ if ! $(wp core is-installed --allow-root --path=/usr/src/wordpress); then
 fi
 
 # Ensure the plugin and theme directories exist
-mkdir -p wp-content/themes
-mkdir -p wp-content/plugins
+mkdir -p /var/www/html/wp-content/themes
+mkdir -p /var/www/html/wp-content/plugins
 
 # Checkout/update VIP plugins
 echo
 echo "Checking out VIP Plugins..."
-if [ -d "wp-content/themes/vip/plugins" ]; then
-  svn up wp-content/themes/vip/plugins
+if [ -d "/var/www/html/wp-content/themes/vip/plugins" ]; then
+  svn up /var/www/html/wp-content/themes/vip/plugins
 else
-  mkdir -p wp-content/themes/vip
-  svn co https://vip-svn.wordpress.com/plugins/ wp-content/themes/vip/plugins
+  mkdir -p /var/www/html/wp-content/themes/vip
+  svn co https://vip-svn.wordpress.com/plugins/ /var/www/html/wp-content/themes/vip/plugins
 fi
 
 # Checkout/update default theme
 echo
 echo "Checking out default theme..."
-if [ -d "wp-content/themes/pub/twentysixteen" ]; then
-  svn up wp-content/themes/pub/twentysixteen
+if [ -d "/var/www/html/wp-content/themes/pub/twentysixteen" ]; then
+  svn up /var/www/html/wp-content/themes/pub/twentysixteen
 else
-  mkdir -p wp-content/themes/pub
-  svn co https://wpcom-themes.svn.automattic.com/twentysixteen wp-content/themes/pub/twentysixteen
+  mkdir -p /var/www/html/wp-content/themes/pub
+  svn co https://wpcom-themes.svn.automattic.com/twentysixteen /var/www/html/wp-content/themes/pub/twentysixteen
 fi
 
 # Clone Jetpack
 echo
 echo "Cloning Jetpack..."
-if [ -d "wp-content/plugins/jetpack" ]; then
-  cd wp-content/plugins/jetpack
+if [ -d "/var/www/html/wp-content/plugins/jetpack" ]; then
+  cd /var/www/html/wp-content/plugins/jetpack
   git reset --hard
   git pull
   cd -
 else
-  git clone -b master-stable https://github.com/Automattic/jetpack.git wp-content/plugins/jetpack
+  git clone -b master-stable https://github.com/Automattic/jetpack.git /var/www/html/wp-content/plugins/jetpack
 fi
 
 

--- a/.docker/nginx.template
+++ b/.docker/nginx.template
@@ -2,7 +2,7 @@ server {
 	listen $NGINX_PORT default;
 	server_name _;
 
-	root /usr/src/wordpress;
+	root /var/www/html/wordpress;
 	index index.php index.html;
 
 	# Block all requests to hidden files

--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -3,3 +3,5 @@ memory_limit = 64M
 upload_max_filesize = 64M
 post_max_size = 64M
 max_execution_time = 30
+xdebug.remote_enable=on
+xdebug.remote_autostart=off

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ wp-content/uploads
 wp-content/upgrade
 wp-config/secrets.php
 
+wordpress
+
 # Database
 .data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ RUN apt-get update && apt-get install -y \
     libmemcached-dev \
     curl
 
+RUN yes | pecl install xdebug \
+    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+
 RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
     && mkdir -p /usr/src/php/ext/memcached \
     && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM php:fpm
 
 # Install memcached for PHP 7
 RUN apt-get update && apt-get install -y \
+    mariadb-client \
+    libpng12-dev \
+    libjpeg-dev \
     libpq-dev \
     libmemcached-dev \
     curl \
     git \
-    subversion
+    subversion && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+    && docker-php-ext-install gd mysqli opcache
 
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
@@ -19,11 +24,6 @@ RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-m
     && docker-php-ext-configure memcached \
     && docker-php-ext-install memcached \
     && rm /tmp/memcached.tar.gz
-
-# install the PHP extensions we need for WordPress
-RUN apt-get update && apt-get install -y mariadb-client libpng12-dev libjpeg-dev && rm -rf /var/lib/apt/lists/* \
-	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-	&& docker-php-ext-install gd mysqli opcache
 
 ENV WORDPRESS_VERSION 4.7.1
 ENV WORDPRESS_SHA1 8e56ba56c10a3f245c616b13e46bd996f63793d6

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,28 +2,33 @@ FROM php:fpm
 
 # Install memcached for PHP 7
 RUN apt-get update && apt-get install -y \
-    mariadb-client \
-    libpng12-dev \
-    libjpeg-dev \
-    libpq-dev \
-    libmemcached-dev \
-    curl \
-    git \
-    subversion && rm -rf /var/lib/apt/lists/* \
-    && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mysqli opcache
-
-RUN yes | pecl install xdebug \
-    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
+      curl \
+      libjpeg-dev \
+      libmemcached-dev \
+      libpng12-dev \
+      libpq-dev \
+      mariadb-client \
+    && rm -rf /var/lib/apt/lists/* 
 
 RUN curl -L -o /tmp/memcached.tar.gz "https://github.com/php-memcached-dev/php-memcached/archive/php7.tar.gz" \
     && mkdir -p /usr/src/php/ext/memcached \
     && tar -C /usr/src/php/ext/memcached -zxvf /tmp/memcached.tar.gz --strip 1 \
     && docker-php-ext-configure memcached \
-    && docker-php-ext-install memcached \
+    && docker-php-ext-configure \
+      gd \
+      --with-png-dir=/usr \
+      --with-jpeg-dir=/usr \
+    && docker-php-ext-install \
+      gd \
+      memcached \
+      mysqli \
+      opcache \
     && rm /tmp/memcached.tar.gz
+
+RUN yes | pecl install xdebug \
+    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 ENV WORDPRESS_VERSION 4.7.1
 ENV WORDPRESS_SHA1 8e56ba56c10a3f245c616b13e46bd996f63793d6

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yes | pecl install xdebug \
 
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
-COPY .docker/wp-config.php /var/www/html/wordpress
+COPY .docker/wp-config.php /var/www/html/wordpress/
 #VOLUME /var/www/html/wordpress
 WORKDIR /var/www/html/wordpress
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN yes | pecl install xdebug \
 
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
-COPY .docker/wp-config.php /var/www/html/wordpress/
+COPY .docker/wp-config.php /var/www/html/
 WORKDIR /var/www/html/wordpress/
 
 # Install wp-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM php:fpm
 RUN apt-get update && apt-get install -y \
     libpq-dev \
     libmemcached-dev \
-    curl
+    curl \
+    git \
+    subversion
 
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,15 +30,6 @@ RUN yes | pecl install xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini
 
-ENV WORDPRESS_VERSION 4.7.1
-ENV WORDPRESS_SHA1 8e56ba56c10a3f245c616b13e46bd996f63793d6
-
-RUN curl -o wordpress.tar.gz -SL https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz \
-	&& echo "$WORDPRESS_SHA1 *wordpress.tar.gz" | sha1sum -c - \
-	&& tar -xzf wordpress.tar.gz -C /usr/src/ \
-	&& rm wordpress.tar.gz \
-	&& chown -R www-data:www-data /usr/src/wordpress
-
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
 COPY .docker/wp-config.php /usr/src/wordpress

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN yes | pecl install xdebug \
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
 COPY .docker/wp-config.php /var/www/html/wordpress
-VOLUME /var/www/html/wordpress
+#VOLUME /var/www/html/wordpress
 WORKDIR /var/www/html/wordpress
 
 # Install wp-cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y \
       libmemcached-dev \
       libpng12-dev \
       libpq-dev \
+      git \
+      subversion \
       mariadb-client \
     && rm -rf /var/lib/apt/lists/* 
 
@@ -33,8 +35,7 @@ RUN yes | pecl install xdebug \
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
 COPY .docker/wp-config.php /var/www/html/wordpress/
-#VOLUME /var/www/html/wordpress
-WORKDIR /var/www/html/wordpress
+WORKDIR /var/www/html/wordpress/
 
 # Install wp-cli
 RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN yes | pecl install xdebug \
 
 COPY .docker/php.ini /usr/local/etc/php/conf.d/wordpress.ini
 
-COPY .docker/wp-config.php /usr/src/wordpress
-VOLUME /usr/src/wordpress
-WORKDIR /usr/src/wordpress
+COPY .docker/wp-config.php /var/www/html/wordpress
+VOLUME /var/www/html/wordpress
+WORKDIR /var/www/html/wordpress
 
 # Install wp-cli
 RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \

--- a/bin/up
+++ b/bin/up
@@ -1,41 +1,5 @@
 #!/bin/bash
 
-# Ensure the plugin and theme directories exist
-mkdir -p wp-content/themes
-mkdir -p wp-content/plugins
-
-# Checkout/update VIP plugins
-echo
-echo "Checking out VIP Plugins..."
-if [ -d "wp-content/themes/vip/plugins" ]; then
-	svn up wp-content/themes/vip/plugins
-else
-	mkdir -p wp-content/themes/vip
-	svn co https://vip-svn.wordpress.com/plugins/ wp-content/themes/vip/plugins
-fi
-
-# Checkout/update default theme
-echo
-echo "Checking out default theme..."
-if [ -d "wp-content/themes/pub/twentysixteen" ]; then
-	svn up wp-content/themes/pub/twentysixteen
-else
-	mkdir -p wp-content/themes/pub
-	svn co https://wpcom-themes.svn.automattic.com/twentysixteen wp-content/themes/pub/twentysixteen
-fi
-
-# Clone Jetpack
-echo
-echo "Cloning Jetpack..."
-if [ -d "wp-content/plugins/jetpack" ]; then
-	cd wp-content/plugins/jetpack
-	git reset --hard
-	git pull
-	cd -
-else
-	git clone -b master-stable https://github.com/Automattic/jetpack.git wp-content/plugins/jetpack
-fi
-
 # Update containers
 echo
 echo "Updating containers"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
             WP_DOMAIN: wp.local
             WP_ADMIN_USER: wordpress
             WP_EMAIL: wordpress@wp.local
-
+            XDEBUG_CONFIG: remote_host={{YOUR_LOCAL_IP_ADDRESS}}
+            PHP_IDE_CONFIG: serverName=vip.local
     nginx:
         image: nginx:mainline
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
             - mysql
             - memcached
         volumes:
+            - "./wordpress:/var/www/html/wwordpress"
             - "./wp-content:/var/www/html/wp-content"
             - "./wp-config:/var/www/html/wp-config:ro"
         environment:
@@ -21,6 +22,7 @@ services:
     nginx:
         image: nginx:mainline
         volumes:
+            - "./wordpress:/var/www/html/wordpress:ro"
             - "./wp-content:/var/www/html/wp-content:ro"
             - ".docker/nginx.template:/etc/nginx/conf.d/wordpress.template:ro"
         volumes_from:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
             - mysql
             - memcached
         volumes:
-            - "./wordpress:/var/www/html/wwordpress"
+            - "./wordpress:/var/www/html/wordpress"
             - "./wp-content:/var/www/html/wp-content"
             - "./wp-config:/var/www/html/wp-config:ro"
         environment:


### PR DESCRIPTION
WIP, will fix #7, and remove the need to use `bin/up` to start the container, standard docker commands can be used instead. Necessary for dockerhub automated image builds